### PR TITLE
Add viewport meta & charset

### DIFF
--- a/wiki/templates/master_template.html
+++ b/wiki/templates/master_template.html
@@ -1,5 +1,8 @@
 <html lang="en-us">
 <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ title }}</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/styles/default.min.css">
     <link rel="stylesheet" href="https://quiltmc.org/assets/css/style.css">


### PR DESCRIPTION
This PR add meta for viewport & charset (utf-8) in the master template page.

These changes can improve the navigation on mobile devices