### PR TITLE
Add issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: QuiltMC Toolchain
+    url: https://discord.quiltmc.org/toolchain
+    about: Join our Discord server if you just have a question


### PR DESCRIPTION
This PR add "issue template config", which displays a link to the Quilt toolchain discord.

![image](https://user-images.githubusercontent.com/40738104/175251446-87b5330f-ce19-4147-8c67-bbf4de9e94f8.png)
