### PR TITLE
Fix git_repo_tree value

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 wiki_path = http://localhost:3000
 test_port = 3000
 output_path = docs
-git_repo_tree = https://github.com/QuiltMC/developer-wiki/tree/master
+git_repo_tree = https://github.com/QuiltMC/developer-wiki/tree/main
 
 org.gradle.jvmargs = -Xmx1G
 org.gradle.parallel = true


### PR DESCRIPTION
This PR fix git_repo_tree value to fit with recent rename of master branch to main.