### PR TITLE
Update github-pages-deploy-action to 4.3.4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,9 +32,8 @@ jobs:
           ./gradlew generateWiki -Pwiki_path=https://modder.wiki.quiltmc.org
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.3.3
+        uses: JamesIves/github-pages-deploy-action@v4.3.4
         with:
-          branch: gh-pages
           folder: docs
           clean-exclude: pr-preview/
           force: false


### PR DESCRIPTION
This PR update github-pages-deploy-action to 4.3.4.

This update allow to delete branch param

https://github.com/JamesIves/github-pages-deploy-action/releases/tag/v4.3.4
https://github.com/Mysterious-Dev/Test-Wiki/actions/runs/2598871851