### PR TITLE
Add operating system & web browser fields for bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -18,7 +18,7 @@ body:
   - type: input
     attributes:
       label: Other
-      description: What is your operating system (for people how choose Other)?
+      description: What is your operating system (for people who have chosen **Other**)?
     validations:
       required: false
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -18,7 +18,7 @@ body:
   - type: input
     attributes:
       label: Other
-      description: What is your operating system (for people who have chosen **Other**)?
+      description: What is your operating system (for peoples who have chosen **Other**)?
     validations:
       required: false
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -2,6 +2,22 @@ name: Bug report
 description: Reporting an issue
 labels: ["bug"]
 body:
+  - type: dropdown
+    attributes:
+      label: Operating System
+      description: On which operating system do you have a problem?
+      options:
+        - Windows
+        - MacOS
+        - Linux
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Web Browser
+      description: On which web browser do you have a problem?
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: Issue description

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -2,25 +2,12 @@ name: Bug report
 description: Reporting an issue
 labels: ["bug"]
 body:
-  - type: dropdown
+  - type: input
     attributes:
       label: Operating System
       description: On which operating system do you have a problem?
-      options:
-        - Windows
-        - MacOS
-        - Linux
-        - Android
-        - IOS
-        - Other
     validations:
       required: true
-  - type: input
-    attributes:
-      label: Other
-      description: What is your operating system (for peoples who have chosen **Other**)?
-    validations:
-      required: false
   - type: input
     attributes:
       label: Web Browser

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -10,8 +10,17 @@ body:
         - Windows
         - MacOS
         - Linux
+        - Android
+        - IOS
+        - Other
     validations:
       required: true
+  - type: input
+    attributes:
+      label: Other
+      description: What is your operating system (for people how choose Other)?
+    validations:
+      required: false
   - type: input
     attributes:
       label: Web Browser


### PR DESCRIPTION
This PR add 2 fields for bug report form. One of them is for operating system and the other for web browser.

![image](https://user-images.githubusercontent.com/40738104/180849416-d58a57f1-1223-41e2-b232-1acd87119140.png)

