### PR TITLE
Change Forge docs URL to docs.minecraftforge.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 This wiki is specifically for developers, not users, of Quilt to learn how to make mods
 
 ### What makes this wiki different from other wikis?
-Each loader has their own wiki [Fabric](https://fabricmc.net/wiki/doku.php) and [Forge](https://mcforge.readthedocs.io/). 
+Each loader has their own wiki [Fabric](https://fabricmc.net/wiki/doku.php) and [Forge](https://docs.minecraftforge.net/). 
 While Forge's wiki is has a better design for modders than Fabric's, 
 which often has outdated tutorials or hard to find tutorials for old versions and is not managed through git, 
 they both lack one critical feature that would bring them to the next level: **Real code**. 


### PR DESCRIPTION
This PR changes the link to the official Forge docs in the README from the old URL of https://mcforge.readthedocs.io/ to the new canonical URL of https://docs.minecraftforge.net/. As a note, the old URL still functions perfectly fine, and redirects to the new domain automatically.