### PR TITLE
Fix code punctuation color

### DIFF
--- a/wiki/static/dracula.css
+++ b/wiki/static/dracula.css
@@ -1,5 +1,7 @@
 @import "dracula-dark.css" (prefers-color-scheme: dark);
 
-.hljs-punctuation {
-  color: white;
+@media(prefers-color-scheme: dark) {
+    .hljs-punctuation {
+        color: white;
+    }
 }

--- a/wiki/static/dracula.css
+++ b/wiki/static/dracula.css
@@ -1,1 +1,5 @@
 @import "dracula-dark.css" (prefers-color-scheme: dark);
+
+.hljs-punctuation {
+  color: white;
+}


### PR DESCRIPTION
This fixes code punctuation color, as currently it is near-impossible to see.

Before:

 ![Before](https://media.discordapp.net/attachments/984628700635099196/1015185912650547210/unknown.png)

After: 

![After](https://media.discordapp.net/attachments/984628700635099196/1015186395402350594/unknown.png)