### PR TITLE
 Fix markdown not displaying list correctly in items wiki

### DIFF
--- a/wiki/versions/1.19/item/simple_item/markdown/simple_item.md
+++ b/wiki/versions/1.19/item/simple_item/markdown/simple_item.md
@@ -19,6 +19,7 @@ Now that we've declared the item, we need to tell the game registry to put it in
 ```
 
 `Registry.register()` takes three parameters:
+
 - The `Registry` we want to add to. For items this is always `Registry.ITEM`.
 - The `Identifier` used for the item. This must be unique. The first part is the namespace (which should be the mod id, but here it is `simple_item`) and the item name itself. Only lowercase letters, numbers, underscores, dashes, periods, and slashes are allowed.
 - The `Item` to register. Here, we pass in the item we declared earlier.


### PR DESCRIPTION
This fixes a markdown list not being parsed near the bottom of [Your First Item # Registering the item](https://modder.wiki.quiltmc.org/versions/1.19/item/simple_item/#registering-the-item)

A newline is missing after [line 21](https://github.com/QuiltMC/developer-wiki/blob/1b07e87a0626480b156a62011893c7639c997b03/wiki/versions/1.19/item/simple_item/markdown/simple_item.md?plain=1#L21)

(Feel free to fix it yourself)