### PR TITLE
[Rewrite] Add create item tutorial 

### DIFF
--- a/wiki/introduction/first-item.md
+++ b/wiki/introduction/first-item.md
@@ -1,0 +1,82 @@
+---
+title: Creating your first Item
+---
+
+# Creating your first item
+
+<!-- This is migrated from the old wiki and modified to match 1.20, with some additions -->
+Items are crucial to Minecraft, and almost any mod will make use of them. This tutorial will go through the basic steps for creating an item.
+
+## Registering the Item
+The first thing we need to do is register the item so that the game knows to add it in. [Registries](TODO) are an integral part to Minecraft (and modding it). Blocks, Entities, Items, Sounds, Particles,... all those different aspects are using a registry. First, we need to declare an instance of `net.minecraft.item.Item` with the parameters for our item.
+
+In theory, we could do this directly in the registration line but having a separate variable allows us to reference it elsewhere for other purposes.
+
+```java
+public static final Item EXAMPLE_ITEM = new Item(new QuiltItemSettings());
+```
+
+Here, the `public static final` ensures that we can access the item elsewhere but not change the contents of the variable itself, making sure that we don't accidentally alter it somewhere else.
+
+Our new instance of `Item` takes in an instance of `QuiltItemSettings` as an argument. This is where we declare all of the settings for our item. There are a variety of these, such as the durability, but in this case we can just use the default settings.
+
+Now that we've declared the item, we need to tell the game registry to put it into the game. We do so by putting this into the mod's `onInitialize` method:
+
+```java
+Registry.register(Registries.ITEM, new Identifier(mod.metadata().id(), "example_item"), EXAMPLE_ITEM);
+```
+
+`Registry.register()` takes three parameters:
+
+- The `Registry` we want to add to. For items this is always `Registries.ITEM`.
+- The `Identifier` used for the item. This must be unique. The first part is the namespace (which should be the mod id, but here it is `simple_item`) and the item name itself. Only lowercase letters, numbers, underscores, dashes, periods, and slashes are allowed.
+- The `Item` to register. Here, we pass in the item we declared earlier.
+
+Having done all of this, if we run the game we can see that we can give the item using the give command: `/give @s simple_item:example_item`! But it doesn't appear in the creative menu, nor does have a texture, and its name isn't translated properly. How do we fix this?
+
+## Adding the Item to a group
+
+Because of a change in 1.19.3, you cannot add items to item groups using only QSL. However Fabric API has an API for it. Thanks to Quiltified Fabric API, which the template (and players) use by default, we can use it on Quilt, too:
+
+```java
+ItemGroupEvents.modifyEntriesEvent(ItemGroups.INGREDIENTS).register(entries -> {
+	entries.addStack(EXAMPLE_ITEM.getDefaultStack());
+});
+```
+
+Here we are using the `ItemGroupEvents` API. We get the [Event](TODO) for modifying the `INGREDIENTS` item group and register a new listener. [Events](TODO) have two main use cases. On the one side you can use them to do things when something happens, for example when block gets broken or even simply at each tick. On the other side they can be used for modifying things like item groups, where ordering is important. However in this case we are doing nothing complicated and simply adding the item to the end of the Ingredients item group. This will also add them to search.
+
+## Textures
+First we need to declare the model for the item. This tells the game how to render the item.
+
+`example_item.json`:
+```json
+{
+    "parent": "item/generated",
+    "textures": {
+      "layer0": "simple_item:item/example_item"
+    }
+}
+```
+
+For most items, all you need to do here is replace `simple_item` with your mod ID and `example_item` with the item name you set earlier. This file should go to your assets folder under `/models/item`.
+
+The texture file, as shown in the model, should match the path specified in the `Identifier`, so in our case `textures/item/example_item.png`
+
+## Language Translation
+
+Finally, we need to add a translation. Put this in `lang/en_us.json` in your assets folder, replacing the same values as before:
+
+```json
+{
+  "item.simple_item.example_item": "Example Item"
+}
+```
+
+And that's it! Your item should be fully working.
+
+
+## What's next?
+This tutorial only covers the most basic of items. Check the other item tutorials for more advanced items or [add a simple block](TODO)
+
+If you want your item to have a recipe, generate one from [destruc7i0n's crafting recipe generator](https://crafting.thedestruc7i0n.ca/) (you may want to use a placeholder for the `output` item and then replace it with e.g. `simple_item:example_item`) and then put it in a JSON file under `src/main/resources/data/simple_item/recipes/` (replacing `simple_item` with your mod ID). Further details on item recipes can be found <abbr title="This documentation is not done yet, but it will be soon!">here</abbr>.


### PR DESCRIPTION
The Item Tutorial is mostly migrated from the old wiki, with the following differences:
- Code blocks are directly embedded, I also left out the `// ...` at the end and the beginning of each one beacuse I found them annoying
- I added a small sentence mentioning how important Registries are
- Updated to 1.20 code, including changing the Item group stuff to use FAPI APIs
- Added a add a simple block link at the end