### PR TITLE
Add github actions & fix build errors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,22 @@
+name: Bug report
+description: Reporting an issue
+labels: ["bug"]
+body:
+  - type: input
+    attributes:
+      label: Operating System
+      description: On which operating system do you have a problem?
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Web Browser
+      description: On which web browser do you have a problem?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Issue description
+      description: A short description of the issue
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: QuiltMC Toolchain
+    url: https://discord.quiltmc.org
+    about: Join our Discord server if you just have a question

--- a/.github/ISSUE_TEMPLATE/wiki-request.yaml
+++ b/.github/ISSUE_TEMPLATE/wiki-request.yaml
@@ -1,0 +1,22 @@
+name: Wiki Request
+description: Suggesting a new wiki to add
+labels: ["enhancement"]
+body:
+  - type: textarea
+    attributes:
+      label: What would you like the wiki to cover?
+      description: A short description of the feature you wish the wiki would cover
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Why should this be added to the wiki?
+      description: A brief summary of why you believe this topic belongs on the wiki
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Where in the wiki should this go?
+      description: Suggest a current section or wiki to integrate this into, or a new section.
+    validations:
+      required: true

--- a/.github/workflows/commit-preview.yaml
+++ b/.github/workflows/commit-preview.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: developer-wiki-test
+          projectName: developer-wiki
           directory: build
 
       - name: Add a comment on the commit

--- a/.github/workflows/commit-preview.yaml
+++ b/.github/workflows/commit-preview.yaml
@@ -1,0 +1,40 @@
+on: [push]
+name: Commit preview
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+
+    name: Generate commit preview
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Enable Corepack shims
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build the project
+        run: pnpm build
+
+      - name: Publish to Pages
+        uses: cloudflare/pages-action@1
+        id: publish
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: developer-wiki-test
+          directory: build
+
+      - name: Add a comment on the commit
+        uses: peter-evans/commit-comment@v1
+        with:
+          token: ${{ secrets.COZY_PAT }}
+          repository: ${{ github.repository }}
+          sha: ${{ github.sha }}
+          body: "See preview on Cloudflare Pages: ${{ steps.publish.outputs.url }}"

--- a/.github/workflows/pr-preview-footer.yaml
+++ b/.github/workflows/pr-preview-footer.yaml
@@ -1,0 +1,19 @@
+on:
+  pull_request_target:
+    types: [opened]
+name: Add footer to PR
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+
+    name: Add preview footer to PR
+    steps:
+    - name: Add preview footer to PR
+      uses: devindford/Append_PR_Comment@v1.1.2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        body-template: |
+          ---
+          See preview on Cloudflare Pages: https://preview-${{ github.event.number }}.developer-wiki-test.pages.dev
+        body-update-action: 'suffix'

--- a/.github/workflows/pr-preview-footer.yaml
+++ b/.github/workflows/pr-preview-footer.yaml
@@ -15,5 +15,5 @@ jobs:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         body-template: |
           ---
-          See preview on Cloudflare Pages: https://preview-${{ github.event.number }}.developer-wiki-test.pages.dev
+          See preview on Cloudflare Pages: https://preview-${{ github.event.number }}.developer-wiki.pages.dev
         body-update-action: 'suffix'

--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -1,0 +1,30 @@
+on: [pull_request]
+name: PR preview
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    name: Generate PR preview
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Enable Corepack shims
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build the project
+        run: pnpm build
+
+      - name: Upload HTML artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: website-html
+          path: build
+          retention-days: 1
+

--- a/.github/workflows/publish-pr-preview.yaml
+++ b/.github/workflows/publish-pr-preview.yaml
@@ -30,6 +30,6 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: developer-wiki-test
+          projectName: developer-wiki
           directory: build
           branch: preview-${{ steps.pr-details.outputs.pullRequestNumber }}

--- a/.github/workflows/publish-pr-preview.yaml
+++ b/.github/workflows/publish-pr-preview.yaml
@@ -1,0 +1,35 @@
+on:
+  workflow_run:
+    workflows: ["PR preview"]
+    types: [completed]
+name: Publish PR preview
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    name: Publish PR preview
+    steps:
+      - name: Download HTML artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          name: website-html
+          path: build
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Gather PR details
+        uses: potiuk/get-workflow-origin@v1_1
+        id: pr-details
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+
+      - name: Publish to Pages
+        uses: cloudflare/pages-action@1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: developer-wiki-test
+          directory: build
+          branch: preview-${{ steps.pr-details.outputs.pullRequestNumber }}

--- a/wiki/items/first-item.md
+++ b/wiki/items/first-item.md
@@ -45,7 +45,7 @@ Having done all of this, if we run the game we can see that we can give the item
 ## Adding the Item to a Group
 
 `ItemGroup`s represent the tabs in the creative menu.
-Because of a change in 1.19.3, you can't add items to item groups using only [Quilt Standard Libraries](../concepts/qsl-qfapi) (From now on QSL). However, [Fabric API]((../concepts/qsl-qfapi)) has an API for it. Thanks to [Quilted Fabric API](../concepts/qsl-qfapi), which the template mod includes and users download with QSL, we can use it on Quilt, too:
+Because of a change in 1.19.3, you can't add items to item groups using only [Quilt Standard Libraries](../concepts/qsl-qfapi) (From now on QSL). However, [Fabric API](../concepts/qsl-qfapi) has an API for it. Thanks to [Quilted Fabric API](../concepts/qsl-qfapi), which the template mod includes and users download with QSL, we can use it on Quilt, too:
 
 ```java
 ItemGroupEvents.modifyEntriesEvent(ItemGroups.INGREDIENTS).register(entries -> {
@@ -91,4 +91,4 @@ And that's it! Your item should be fully working.
 
 This tutorial only covers the most basic of items. Check the other item tutorials for more advanced items or try [Adding a simple block](../blocks/first-block).
 
-If you want your item to have a recipe, generate one from [destruc7i0n's crafting recipe generator](https://crafting.thedestruc7i0n.ca/) (you can add your mod's items using the "Add Item" button above the ingredient list) and then put it in a JSON file under `resources/data/simple_item_mod/recipes/` (replacing `simple_item_mod` with your mod id). Further details on item recipes can be found on [the dedicated recipe page](.../data/adding-recipes).
+If you want your item to have a recipe, generate one from [destruc7i0n's crafting recipe generator](https://crafting.thedestruc7i0n.ca/) (you can add your mod's items using the "Add Item" button above the ingredient list) and then put it in a JSON file under `resources/data/simple_item_mod/recipes/` (replacing `simple_item_mod` with your mod id). Further details on item recipes can be found on [the dedicated recipe page](../data/adding-recipes).


### PR DESCRIPTION
- Adds commit preview and PR preview github actions
- Fixes build erroring

Notes:
- Requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN secrets to be set
- Requires COZY_PAT token with write access to this repository
- Requires rewrite to be the default branch for PR previews to work
- Currently the rewrite preview on the rewrite branch is done through cloudflare's git integration, it might be needed to switch to manual upload (might work without doing this)