### PR TITLE
Actually render drafts at build time

### DIFF
--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -23,11 +23,11 @@
 			<p class="menu-label">{$t("application.sidebar.articles")}</p>
 			<ul class="menu-list">
 				{#each categories as category}
-					<li>
+					<li class:is-hidden={category.draft}>
 						{$t(category.name)}
 						<ul>
 							{#each category.pages as page}
-								<li>
+								<li class:is-hidden={page.draft}>
 									<a
 										href={`/${$locale}/${category.slug}/${page.slug}`}
 										class:is-active={url === `/${$locale}${category.slug}/${page.slug}`}

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -9,5 +9,6 @@ export interface Category {
 	slug: string;
 	index: number;
 	name: string;
+	draft: boolean;
 	pages: Page[];
 }

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -34,8 +34,6 @@ export async function load({ params }) {
 						draft: page_metadata.draft || false
 					};
 				})
-				// exlude draft pages
-				.filter((page) => !page.draft)
 				.sort((a, b) => a.index - b.index);
 
 			// get the metadata of each category from their yaml file
@@ -50,6 +48,7 @@ export async function load({ params }) {
 						? category_metadata.index
 						: Number.MAX_SAFE_INTEGER, // Put the categories with no index last
 				name: category_metadata.name,
+				draft: pages.length === pages.filter((page) => page.draft).length,
 				pages: pages
 			};
 		})


### PR DESCRIPTION
Fix the issue that prevented drafts to be rendered at build time, making them inaccessible in production. (drafts pages and categories with only drafts pages are still not displayed in the sidebar)

---
See preview on Cloudflare Pages: https://preview-95.developer-wiki.pages.dev