### PR TITLE
feat: landing page translatable content

### DIFF
--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -12,12 +12,18 @@ export async function load({ params }) {
 		.readdirSync(wiki_path)
 		// remove files with extensions (not directories)
 		.filter((file_name) => !file_name.match(/.+\..+/))
+		// remove directories that don't contain a `+category.yml` file
+		.filter((directory_name) => fs.existsSync(`${wiki_path}${directory_name}/+category.yml`))
 		.map((category_slug) => {
 			const pages: Page[] = fs
 				// get the name if each file in this category's folder
 				.readdirSync(`${wiki_path}${category_slug}/`)
 				// remove files with extensions (not directories)
 				.filter((file_name) => !file_name.match(/.+\..+/))
+				// remove directories that don't contain a `+page.yml` file
+				.filter((directory_name) =>
+					fs.existsSync(`${wiki_path}${category_slug}/${directory_name}/+page.yml`)
+				)
 				.map((page_slug) => {
 					// get the metadata of each file from their yaml file
 					const page_metadata = YAML.parse(

--- a/src/routes/[[locale=locale]]/+page.svelte
+++ b/src/routes/[[locale=locale]]/+page.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
 	import { t } from "$lib/translations";
+
+	export let data;
 </script>
 
 <svelte:head>
 	<title>{$t("application.title")}</title>
 </svelte:head>
 
-<h1 class="title">{$t("application.title")}</h1>
+{#if data.content}
+	<svelte:component this={data.content} />
+{/if}

--- a/src/routes/[[locale=locale]]/+page.ts
+++ b/src/routes/[[locale=locale]]/+page.ts
@@ -1,0 +1,26 @@
+import type { ComponentType, SvelteComponent } from "svelte";
+
+import { defaultLocale } from "$lib/translations/index.js";
+
+export async function load({ params }): Promise<{ content: ComponentType<SvelteComponent> }> {
+	try {
+		const landing_page = await import(
+			`../../../wiki/landing-page/${params.locale || defaultLocale}.md`
+		);
+
+		return {
+			content: landing_page.default
+		};
+	} catch (err) {
+		if (err instanceof Error && err.message.match(/Unknown variable dynamic import.+/)) {
+			// Return the english version if the translated version is missing
+			const landing_page = await import(`../../../wiki/landing-page/${defaultLocale}.md`);
+
+			return {
+				content: landing_page.default
+			};
+		} else {
+			throw err;
+		}
+	}
+}

--- a/wiki/landing-page/en.md
+++ b/wiki/landing-page/en.md
@@ -1,0 +1,19 @@
+# Quilt Developer Wiki :P
+
+This site houses heavily work-in-progress documentation for developing with projects in the Quilt ecosystem.
+Check the sidebar to see what articles are currently available!
+
+Keep in mind that when modding with Quilt, this isn't the only source of documentation you can use.
+Here are a few other places to look if you're not seeing what you need:
+
+- The [Fabric wiki](https://fabricmc.net/wiki/tutorial:start), a huge collection of tutorials for modding with vanilla features, Fabric API and Fabric Loader.
+  On Quilt, you'll always have access to Fabric API and Fabric Loader, so all of these tutorials can be used without issue.
+
+- Fabric's [documentation site](https://docs.fabricmc.net/develop/), a work-in-progress modernisation of their wiki.
+  This site has less information than the old wiki, but the tutorials are likely more up-to-date.
+
+- The [Quilt Loader wiki](https://github.com/QuiltMC/quilt-loader/wiki), where you can find some information on Quilt Loader's configuration and features.
+
+- The [Mixin Wiki](https://github.com/SpongePowered/Mixin/wiki) and the [Mixin Extras Wiki](https://github.com/LlamaLad7/MixinExtras/wiki), which provide information on modifying compiled code (in this case, Minecraft's code!) via Mixin.
+
+- The [Minecraft Wiki](https://minecraft.wiki/), which provides comprehensive overviews of vanilla datapacking features that are often useful in modding.

--- a/wiki/landing-page/fr.md
+++ b/wiki/landing-page/fr.md
@@ -1,0 +1,19 @@
+# Wiki pour Développeur·euse·s Quilt :P
+
+Ce contient de la documentation pour le développement de projets dans l'écosystème Quilt très expérimentale.
+Vérifiez la barre latérale pour voir quels articles sont actullement disponibles !
+
+N'oubliez pas que ce site n'est pas la seule source de documentation quand vous moddez avec Quilt.
+Voici d'autres sources d'informations intéressantes que vous pouvez consulter si vous ne trouvez pas ce que vous cherchez:
+
+- Le [wiki de Fabric](https://fabricmc.net/wiki/tutorial:start), une enorme collection de tutoriels pour le modding avec les fonctionnalités vanilla, les API de Fabric et le Fabric Loader.
+  Avec Quilt, vous aurez toujours accès aux API de Fabric et au Fabric Loader donc tous ces tutoriels peuvent être utilisés sans soucis.
+
+- La [documentation de Fabric](https://docs.fabricmc.net/develop/), une modernisation expérimentale de leur wiki.
+  Ce site a moins d'information que leur ancien wiki mais les tutoriels sont probablement plus à jour.
+
+- Le [wiki du Quilt Loader](https://github.com/QuiltMC/quilt-loader/wiki), vous pouvez y trouver des information sur la configuration et les fonctionnalité du Quilt Loader.
+
+- Les wikis [Mixin](https://github.com/SpongePowered/Mixin/wiki) et [MixinExtra](https://github.com/LlamaLad7/MixinExtras/wiki), qui fournissent des information sur la modification de code compilé (le code de Minecraft dans notre cas !) avec des Mixins.
+
+- Le [wiki de Minecraft](https://minecraft.wiki/) qui fournit un apperçu global des fonctionnalités des datapacks vanilla qui sont souvent utiles en modding.


### PR DESCRIPTION
Similar to the wiki pages, one makdown file per locale in $wiki/landing-page

---
See preview on Cloudflare Pages: https://preview-104.developer-wiki.pages.dev