### PR TITLE
fix: change link icon class to use unocss

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -27,6 +27,9 @@
 	export let data;
 </script>
 
+<!-- Needed to tell unocss that the link icon is indeed used -->
+<div class="i-fa6-solid-link is-hidden" />
+
 <HtmlHead />
 
 <input id="low-contrast" type="checkbox" class="is-hidden" />

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -38,13 +38,13 @@ export default {
 						content: {
 							type: "element",
 							tagName: "span",
-							properties: { className: "icon header-anchor-container pl-3" },
+							properties: { className: "header-anchor-container pl-2" },
 							children: [
 								{
 									type: "element",
 									tagName: "i",
 									properties: {
-										className: "header-anchor fas fa-lg fa-link has-text-link is-size-5"
+										className: "header-anchor icon i-fa6-solid-link has-text-link is-size-5"
 									}
 								}
 							]

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -3,11 +3,7 @@ import { defineConfig, presetIcons } from "unocss";
 export default defineConfig({
 	presets: [
 		presetIcons({
-			collections: {
-				"fa6-solid": () => import("@iconify-json/fa6-solid/icons.json").then((i) => i.default),
-				"fa6-brands": () => import("@iconify-json/fa6-brands/icons.json").then((i) => i.default),
-				tabler: () => import("@iconify-json/tabler/icons.json").then((i) => i.default)
-			},
+			// Collections are automatically imported from inconify packages
 			customizations: {
 				iconCustomizer(collection, icon, props) {
 					// Makes the empty cut in half circle slightly larger


### PR DESCRIPTION
Loads the link icon from a css file generated at compile time by unocss (like the other icons)

Allows to not load them from fontawesome at runtime (which is slower) + no need to add a new dependency

Fixes #100 

---
See preview on Cloudflare Pages: https://preview-108.developer-wiki.pages.dev